### PR TITLE
Added info to World Downloader (Radius) section

### DIFF
--- a/docs/source/Knowledge_Base/world_downloader.rst
+++ b/docs/source/Knowledge_Base/world_downloader.rst
@@ -27,6 +27,7 @@ How to: Using Radius
 ====================
 
 1. Add a radius around you to world downloader by running the command ``/wd add radius <number>`` while standing in the desired area. 
+	Note: You can only download the area if it has been claimed by you, or you are trusted in the claim.
 
 * The number is the amount of chunks around you that you want to download. So if you want to download a 4x4 chunk area, put 2 in as that will download the a 4x4 area. Repeat this for all the areas you want to save before moving on to step 2.
 


### PR DESCRIPTION
Added info in the Radius section that the area must be claimed in order to be downloaded. 

When using the radius command in your claim, it will say that the chunks have been added, but only download the actual claimed chunks.